### PR TITLE
feat: Add Git sync and public beta preparation (v0.3.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The application follows the Elm Architecture pattern:
 - Multiple file support
 - In-app editing
 - Task completion toggle (use external editor)
-- Markdown rendering
+- Custom Markdown rendering implementation (library usage is acceptable)
 - Search/filter
 - Tags/metadata
 - Cloud sync
@@ -78,22 +78,22 @@ Completed tasks are archived to `archive.md` after a configurable delay period.
 
 ## Git Branch Strategy
 
-GitHub Flow を採用：
+Adopting GitHub Flow:
 
 ```
-main (常にリリース可能)
-  ├── feature/xxx    # 機能追加
-  ├── fix/xxx        # バグ修正
-  └── docs/xxx       # ドキュメント更新
+main (always releasable)
+  ├── feature/xxx    # Feature additions
+  ├── fix/xxx        # Bug fixes
+  └── docs/xxx       # Documentation updates
 ```
 
-**ルール：**
-- `main` は常にリリース可能な状態を維持
-- 作業は必ずブランチを切って行う
-- 完了したらmainにsquash merge
-- バージョンはタグで管理（`v0.1.0` 等）
+**Rules:**
+- `main` is always kept in a releasable state
+- Work is always done on a branch
+- Squash merge to main when complete
+- Versions are managed with tags (`v0.1.0`, etc.)
 
-**GitHub CLI (gh) が使用可能：**
+**GitHub CLI (gh) is available:**
 ```bash
 gh pr create --title "Add feature" --body "Description"
 gh pr list
@@ -104,23 +104,23 @@ gh release create v0.1.0 --notes "Release notes"
 
 ### Bug Fix Workflow (Issue-Driven)
 
-バグ修正はGitHub Issueを起点として行う：
+Bug fixes are done starting from GitHub Issues:
 
-1. **Issue作成**: バグを発見したら `gh issue create` でIssue作成
-2. **ブランチ作成**: `fix/issue-番号` ブランチを作成
-3. **修正＆テスト**: TDDで修正、`go test ./...` と `golangci-lint run` をパス
-4. **ユーザー確認**: 修正内容をユーザーが検証
-5. **PR作成**: `gh pr create` でPull Request作成
-6. **マージ**: GitHub上でmainにsquash merge
+1. **Create Issue**: When a bug is found, create an issue with `gh issue create`
+2. **Create Branch**: Create a `fix/issue-N` branch
+3. **Fix & Test**: Fix using TDD, pass `go test ./...` and `golangci-lint run`
+4. **User Verification**: User verifies the fix
+5. **Create PR**: Create Pull Request with `gh pr create`
+6. **Merge**: Squash merge to main on GitHub
 
 ```bash
-# 例: Issue #1 のバグ修正
+# Example: Fixing Issue #1
 gh issue create --title "Bug: ..." --body "Description"
 git checkout -b fix/issue-1
-# ... 修正作業 ...
+# ... fix work ...
 go test ./... && golangci-lint run
 gh pr create --title "Fix #1: ..." --body "Closes #1"
-# GitHub上でマージ
+# Merge on GitHub
 ```
 
 ## Development Guidelines (MANDATORY)
@@ -184,7 +184,7 @@ func TestExpandPath(t *testing.T) { ... }              // What ExpandPath() does
 2. **Test comments should reference specification**
    ```go
    // TestConfigPath verifies that ConfigPath() returns ~/.config/ttt/config.toml.
-   // Spec: docs/specification.md "設定ファイル仕様" section
+   // Spec: docs/specification.md "Configuration File Specification" section
    func TestConfigPath(t *testing.T) {
        expected := filepath.Join(home, ".config", "ttt", "config.toml")
        // Exact match, not partial match
@@ -215,4 +215,10 @@ func TestExpandPath(t *testing.T) { ... }              // What ExpandPath() does
 - `docs/concept.md` - Vision and design philosophy (immutable)
 - `docs/specification.md` - Functional specifications (mutable)
 - `docs/architecture.md` - Technology decisions with rationale (mutable)
+- `docs/roadmap.md` - Version plans and future features (mutable)
 - `docs/TODO.md` - Progress tracking
+
+### Documentation Format Rules
+
+- **Updated date format**: `Updated: YYYY-MM-DD.` (with trailing period)
+  - Example: `Updated: 2026-01-22.`

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,26 @@
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -X github.com/yostos/tiny-task-tool/internal/cli.Version=$(VERSION)
 
+# Installation directory
+# Default: $GOPATH/bin or $HOME/go/bin
+# Override with: make install PREFIX=/usr/local
+ifdef PREFIX
+    INSTALL_DIR := $(PREFIX)/bin
+else ifdef GOPATH
+    INSTALL_DIR := $(GOPATH)/bin
+else
+    INSTALL_DIR := $(HOME)/go/bin
+endif
+
 .PHONY: build install test lint clean
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o ttt .
 
 install: build
-	cp ttt ~/bin/
+	@mkdir -p $(INSTALL_DIR)
+	cp ttt $(INSTALL_DIR)/
+	@echo "Installed ttt to $(INSTALL_DIR)/ttt"
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -25,12 +25,32 @@ I was impressed by aeph's approach of bringing the experience to the command lin
 
 ## Installation
 
+### Using go install (Recommended)
+
+```bash
+go install github.com/yostos/tiny-task-tool@latest
+```
+
+Make sure `$GOPATH/bin` or `$HOME/go/bin` is in your PATH.
+
+### Using Homebrew (macOS / Linux)
+
+```bash
+brew install yostos/tap/ttt
+```
+
 ### From Source
 
 ```bash
 git clone https://github.com/yostos/tiny-task-tool.git
 cd tiny-task-tool
 make install
+```
+
+By default, `make install` installs to `$GOPATH/bin` or `$HOME/go/bin`. You can specify a custom directory:
+
+```bash
+make install PREFIX=/usr/local
 ```
 
 ### Requirements
@@ -45,6 +65,8 @@ make install
 ```bash
 ttt                    # Launch TUI
 ttt -t "buy milk"      # Add task quickly
+ttt remote <url>       # Set remote repository
+ttt sync               # Sync with remote (pull → commit → push)
 ttt --help             # Show help
 ttt --version          # Show version
 ```
@@ -155,6 +177,23 @@ ttt automatically manages version control:
 - Initializes a git repository in the working directory
 - Auto-commits changes after edits, archive operations, and task additions
 - Can be disabled with `git.auto_commit = false` in config
+
+### Remote Sync
+
+You can sync your tasks with a remote repository:
+
+```bash
+# Set remote repository (once)
+ttt remote https://github.com/username/my-tasks.git
+
+# Sync with remote
+ttt sync
+```
+
+The `ttt sync` command performs:
+1. `git pull` from remote (skipped on first sync)
+2. Auto-commit any uncommitted changes
+3. `git push` to remote
 
 ## License
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -113,3 +113,116 @@
 
 - [ ] Go言語の慣習に基づいたリリースの準備
 - [ ] Homebrewでのパッケージリリースの準備
+
+### Phase 8: Git同期機能（v0.3.0）
+
+#### 仕様確定
+
+- [x] ユースケースの整理（remote登録、sync）
+- [x] `ttt remote <url>` の動作仕様決定
+- [x] `ttt sync` の動作仕様決定（pull → commit → push）
+- [x] auto_sync を提供しない理由をADRに記録
+- [x] specification.md に仕様追記
+- [x] リポジトリファイル自動生成（README.md, .gitignore）の仕様追記
+
+#### CLI拡張
+
+- [x] サブコマンド対応の設計
+  - 現在: フラグベース（`-t`, `--help`, `--version`）
+  - 追加: 位置引数でサブコマンド検出（`remote`, `sync`）
+- [x] `internal/cli/cli.go` の修正
+  - Options struct に RemoteURL, Sync フィールド追加
+  - Parse() でサブコマンドを検出
+- [x] `internal/cli/cli_test.go` にテスト追加
+
+#### Git操作の実装
+
+- [x] `internal/git/git.go` の新規作成
+  - `SetRemote(dir, url string) error` - リモート設定
+  - `Sync(dir string) error` - pull → commit → push
+  - `HasRemote(dir, name string) bool` - リモート存在確認
+  - `GetCurrentBranch(dir string) (string, error)` - 現在のブランチ取得
+- [x] `internal/git/git_test.go` にテスト追加
+
+#### main.go の修正
+
+- [x] サブコマンドのルーティング追加
+  - `opts.RemoteURL != ""` → `setRemote(cfg, opts.RemoteURL)`
+  - `opts.Sync` → `syncTasks(cfg)`
+- [x] エラーハンドリング
+  - リモート未設定時のエラーメッセージ
+  - 初回sync時（リモートにブランチなし）のハンドリング
+- [x] `ensureRepoFiles()` - README.md, .gitignore 自動生成
+- [x] `main_test.go` にテスト追加
+
+#### ヘルプの更新
+
+- [x] `cli.Usage()` に `remote` と `sync` を追加
+- [x] README.md に使用例を追記
+
+#### テスト
+
+- [x] ユニットテスト
+  - CLI引数パース（`ttt remote <url>`, `ttt sync`）
+  - Git操作（SetRemote, Sync, HasRemote, GetCurrentBranch）
+  - リポジトリファイル生成（ensureRepoFiles）
+- [x] 自動テスト実行（go test ./... && golangci-lint run）
+
+#### ユーザーテスト項目
+
+- [x] `ttt remote <url>` でリモート登録
+  - 新規登録: `git remote -v` で origin が設定されるか確認
+  - 更新: 既存のoriginがある場合、URLが更新されるか確認
+- [x] `ttt sync` で同期
+  - 正常系: ローカルの変更がリモートにpushされるか確認
+  - 初回sync: リモートにブランチがない場合もpush成功
+- [x] エラーケース
+  - リモート未設定時に `ttt sync` → 適切なエラーメッセージ
+
+#### 公開用β版の準備
+
+##### Go言語の慣習に基づいたリリースの準備
+
+- [x] 仕様: `go install github.com/yostos/tiny-task-tool@latest` で直接インストール可能
+- [x] Makefile の修正
+  - `make install` → `go install` を使用（$GOPATH/bin へ）
+  - `make install PREFIX=/usr/local` → 指定先の bin/ へコピー
+- [x] README.md にインストール手順を追記
+  - go install でのインストール方法
+  - make install でのインストール方法
+  - PATH 設定の説明
+
+##### Homebrewでのパッケージリリースの準備
+
+- [x] homebrew-tap リポジトリの作成（github.com/yostos/homebrew-tap）
+- [x] Homebrew formula の作成（ttt.rb）
+- [x] README.md に `brew install yostos/tap/ttt` を追記
+
+##### ドキュメントの英語化
+
+- [x] docs/concept.md → 英語化
+- [x] docs/specification.md → 英語化
+- [x] docs/architecture.md → 英語化
+- [x] docs/roadmap.md → 英語化
+- [x] CLAUDE.md → 英語化（日本語部分）
+- [x] README.md → 英語で記述（インストール手順含む）
+
+**注意:** TODO.md は日本語のまま維持
+
+#### リリース作業（未実施）
+
+- [ ] コミット
+- [ ] PR作成
+- [ ] マージ
+- [ ] v0.3.0 タグ作成
+- [ ] CHANGELOG.md 更新
+- [ ] GitHub Release 公開
+
+#### リリース作業
+
+- [ ] コミット
+- [ ] PR作成
+- [ ] マージ
+- [ ] v0.3.0 タグ作成
+- [ ] CHANGELOG.md 更新
+- [ ] GitHub Release 公開

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -1,169 +1,169 @@
-# ttt (Tiny Task Tool) - プロジェクトコンセプト
+# ttt (Tiny Task Tool) - Project Concept
 
-Updated: 2026-01-18
+Updated: 2026-01-22.
 
-## この文書について
+## About This Document
 
-この文書は ttt (Tiny Task Tool) の構想と設計思想を記述します。
-具体的な仕様については [specification.md](specification.md) を参照してください。
+This document describes the vision and design philosophy of ttt (Tiny Task Tool).
+For detailed specifications, see [specification.md](specification.md).
 
-## ビジョンと動機
+## Vision and Motivation
 
-### なぜ作るのか
+### Why Build This
 
-ターミナル環境で作業していると、頭の中の雑念やタスクを書き出したくなる瞬間があります。
-コードを書いている最中に「あれもやらなきゃ」と思いついたり、複数のタスクが頭の中で絡み合ったりします。
+When working in the terminal, there are moments when you want to write down the clutter in your head—random thoughts and tasks.
+While coding, you might think "I need to do that too," or multiple tasks get tangled in your mind.
 
-そんな時、物理的な紙とペンがあれば書き出せるのですが、ターミナルから手を離してペンを取るのは面倒です。
-かといって、既存のTodoアプリは機能が多すぎて、かえって思考を邪魔してしまいます。
+In such moments, physical paper and pen would let you write things down, but reaching for a pen while working in the terminal is inconvenient.
+On the other hand, existing todo apps have too many features and end up interrupting your thinking instead.
 
-欲しいのは「デジタルの一枚の紙」です。
-ターミナルからコマンド一つで開ける、シンプルな書き捨ての場所です。
+What I want is a "digital sheet of paper."
+A simple scratch space that opens with a single command from the terminal.
 
-### 既存ツールの課題
+### Problems with Existing Tools
 
-#### 1. Todoアプリの問題点
+#### 1. Issues with Todo Apps
 
-多くのTodoアプリは、プロジェクト管理、優先度設定、期限管理、タグ付け、カテゴリ分類など、機能が豊富すぎます。
-「どのプロジェクトに入れよう」「優先度は？」「タグは何にしよう」と考えているうちに、書きたかったことを忘れてしまいます。
+Many todo apps are feature-rich: project management, priority settings, deadlines, tags, categories, and more.
+While thinking "which project should this go in?" "what priority?" "what tag?", you forget what you wanted to write.
 
-メモを管理するために脳のリソースを使うのは本末転倒です。
+Using brain resources to manage notes defeats the purpose.
 
-#### 2. Markdownエディタの問題点
+#### 2. Issues with Markdown Editors
 
-Obsidian、Notion、Joplinなどは強力ですが、これらも「ノートを管理する」ことに重きを置いています。
-ファイル名をどうするか、どのフォルダに保存するか、リンクをどう張るかなど考える必要があります。
+Obsidian, Notion, Joplin, and similar tools are powerful, but they also focus on "managing notes."
+You need to think about what to name the file, which folder to save it in, how to link things.
 
-ただ「今日のことを走り書きしたい」だけなのに、考えることが多すぎます。
+When all you want is to "jot down today's thoughts," there's too much to think about.
 
-#### 3. ターミナルから離れる問題
+#### 3. The Problem of Leaving the Terminal
 
-既存の多くのツールはGUIアプリです。
-ターミナルで作業している時、別のウィンドウを開いてアプリを起動し、書いて、また戻ってきます。
-この「文脈の切り替え」が思考の流れを断ち切ってしまいます。
+Many existing tools are GUI applications.
+When working in the terminal, you have to open another window, launch an app, write, then come back.
+This "context switch" breaks the flow of thought.
 
-#### 4. CLI系類似ツールの問題点
+#### 4. Issues with Similar CLI Tools
 
-ターミナル向けのMarkdownツールも存在しますが、ファイル選択や複数ファイル対応など、機能が増えるにつれて「一枚の紙」というシンプルさから離れていく傾向があります。
+Terminal-based Markdown tools exist, but as features like file selection and multiple file support are added, they tend to drift away from the simplicity of "one sheet of paper."
 
-便利さを追求するあまり、選択肢が増え、結局は「どのファイルに書こう」という判断を迫られます。
+In pursuing convenience, options multiply, and eventually you're forced to decide "which file should I write in?"
 
-### 実現したい体験
+### The Experience I Want to Achieve
 
-理想は、物理的なメモ用紙のシンプルさです。
+The ideal is the simplicity of physical memo paper.
 
-机の上に一枚の紙があります。思いついたことをサッと書きます。
-タスクが終わったら線を引いて消します。紙が埋まったら捨てます。
-それだけです。
+There's a sheet of paper on your desk. You quickly write down what comes to mind.
+When a task is done, you cross it out. When the paper fills up, you throw it away.
+That's it.
 
-これをターミナルの中で再現したいのです。
+I want to recreate this in the terminal.
 
-朝、ターミナルを開きます。コマンド一つで今日の紙が目の前に現れます。
-タスクを眺め、完了したものにチェックを入れます。
-新しいことを書きたくなったら、慣れたエディタ（VimやNeovimなど）で書きます。
-完了したタスクは、コマンド一つでアーカイブに流れていきます。
+In the morning, you open the terminal. With one command, today's paper appears.
+You look at your tasks and check off completed ones.
+When you want to write something new, you use your familiar editor (Vim, Neovim, etc.).
+Completed tasks flow into the archive with a single command.
 
-思考の整理に必要な機能だけがあり、それ以外は何もありません。
-ターミナルから離れずに、静かに思考を整理できる場所です。
+Only the features needed for organizing thoughts exist—nothing more.
+A quiet place to organize your thinking without leaving the terminal.
 
-## 設計哲学
+## Design Philosophy
 
-### 核心的な考え方
+### Core Ideas
 
-- 「一枚の紙」という制約
-  - 物理的なメモ用紙は一枚です。複数の紙を広げて管理したりしません。だからこそシンプルで、迷いがありません。
-  - このツールも同じです。ファイルは常に一つです。
-    「どのファイルに書こう」という選択を強制的に排除します。
-- 「今」に集中する
-  - 頭の中のノイズ—アイデア、タスク、心配事—を書き出す場所です。
-  - 思いついた瞬間にすぐ書き留める。それが目的です。
-  - 過去のメモを検索したり、整理したりする機能は要りません。
-  - 書くことで思考が整理され、心が軽くなる。
-- 「ノード指向」の管理
-  - 人はインデントされた行の塊を、一つのまとまりとして認識します。
-  - このツールは行単位ではなく、ノード（親子関係を含む構造）単位でタスクを扱います。
-  - 親タスクを完了すれば子も完了し、アーカイブすれば子も一緒に移動します。
-  - 実装は複雑になりますが、人間の感覚に寄り添うことを優先します。
-- Unix哲学に従う
-  - 「一つのことをうまくやる」です。
-  - このツールは「Markdownの閲覧」と「タスクのアーカイブ」だけをやります。
-  - 編集は外部エディタに任せます。検索はgrepに任せます。バージョン管理はgitに任せます。
-  - すべてを一つのツールで解決しようとしません。
+- The "One Sheet of Paper" Constraint
+  - Physical memo paper is one sheet. You don't spread out multiple papers to manage them. That's why it's simple, with no hesitation.
+  - This tool is the same. There's always one file.
+    The choice of "which file should I write in?" is forcibly eliminated.
+- Focus on "Now"
+  - A place to write out the noise in your head—ideas, tasks, worries.
+  - Capture thoughts the moment they occur. That's the purpose.
+  - Features to search or organize past notes are unnecessary.
+  - Writing organizes your thoughts and lightens your mind.
+- "Node-Oriented" Management
+  - People perceive indented blocks of lines as a single unit.
+  - This tool handles tasks not as lines, but as nodes (structures including parent-child relationships).
+  - Completing a parent completes its children; archiving moves children together.
+  - Implementation becomes complex, but aligning with human intuition takes priority.
+- Follow Unix Philosophy
+  - "Do one thing well."
+  - This tool only does "viewing Markdown" and "archiving tasks."
+  - Editing is left to external editors. Searching is left to grep. Version control is left to git.
+  - We don't try to solve everything in one tool.
 
-### 最も大切にする価値
+### Most Important Values
 
-1. シンプルさ：機能を足すことより、削ることに価値があります。
-2. 摩擦の排除：起動も終了も一瞬で、思考を邪魔しません。
-3. テキスト指向。Markdownのシンプルな記法に限定する。
-4. 慣れたツールとの共存：編集はユーザーの好きなエディタで行います。
-5. 可能な限りシンプルなキー操作を目指します。
-6. エディタやキー操作は設定ファイルでカスタマイズ可能とします。
+1. Simplicity: Removing features has more value than adding them.
+2. Eliminating friction: Startup and exit are instant, never interrupting thought.
+3. Text-oriented: Limited to simple Markdown notation.
+4. Coexistence with familiar tools: Editing is done with the user's preferred editor.
+5. Aim for the simplest possible key operations.
+6. Editor and key operations are customizable via configuration file.
 
-### やること
+### What We Do
 
-- Markdownファイルの閲覧。
-- 新規完了タスク（`- [x]`）の検出と`@done(日付)`自動追加
-- 完了タスクのアーカイブ
-- 外部エディタの呼び出し
+- View Markdown files.
+- Detect newly completed tasks (`- [x]`) and automatically add `@done(date)`
+- Archive completed tasks
+- Invoke external editor
 
-### やらないこと
+### What We Don't Do
 
-- ファイル指定（コマンドライン引数でのファイル指定は行わない。「どのファイルを開くか」という選択を排除する）
-- 複数ファイル管理（一枚の紙の原則に反する）
-- ファイル内編集（外部エディタに任せる）
-- タスクの完了/未完了切り替え（外部エディタに任せる）
-- Markdownレンダリング（`#`は`#`のまま見える方が思考の整理に良い）
-- リッチな機能追加（検索、タグ、メタデータ等）
-- クラウド同期やAI機能
+- File specification (no file specification via command-line arguments; eliminate the choice of "which file to open")
+- Multiple file management (violates the one sheet of paper principle)
+- In-file editing (leave to external editor)
+- Toggle task completion (leave to external editor)
+- Custom Markdown rendering implementation (library usage is acceptable; low development priority)
+- Rich feature additions (search, tags, metadata, etc.)
+- Cloud sync or AI features
 
-### 意図的に除外するもの
+### Intentionally Excluded
 
-これらは設計思想に基づき、永久に実装しません。
+These will never be implemented, based on design philosophy.
 
-- コマンドライン引数でのファイル指定
-- 複数ファイル対応
-- ファイル内編集機能
-- タスクの完了/未完了切り替え（エディタに任せる）
-- Markdownレンダリング
-- 検索・フィルタ機能
-- タグやメタデータ
-- クラウド同期
-- AI機能
+- File specification via command-line arguments
+- Multiple file support
+- In-file editing functionality
+- Task completion toggle (leave to editor)
+- Custom Markdown rendering implementation (library usage is acceptable)
+- Search/filter functionality
+- Tags or metadata
+- Cloud sync
+- AI features
 
-### トレードオフの判断基準
+### Trade-off Decision Criteria
 
-機能追加の提案があった時、以下を自問する。
+When a feature addition is proposed, ask yourself:
 
-- これは「一枚の紙」の体験を壊さないか？
-- これは外部ツールに任せられないか？
-- これは本当に「今日」のために必要か？
+- Does this break the "one sheet of paper" experience?
+- Can this be left to external tools?
+- Is this really needed for "today"?
 
-迷ったら、削る方を選ぶ。
+When in doubt, choose to remove.
 
-## ターゲットユーザー
+## Target Users
 
-### 想定するユーザー
+### Expected Users
 
-- ターミナルで作業することが多い開発者、ライター、研究者
-- VimやNeovim、Visual Studio Codeなど、好みのエディタを持っている
-- 「シンプルなメモ用紙」の価値を理解している
-- 多機能なTodoアプリやノートアプリに疲れている
+- Developers, writers, researchers who often work in the terminal
+- Have a preferred editor like Vim, Neovim, Visual Studio Code
+- Understand the value of a "simple memo pad"
+- Tired of feature-rich todo apps and note apps
 
-## このツールの立ち位置
+## Positioning of This Tool
 
-### 他のツールとの比較
+### Comparison with Other Tools
 
-| 観点         | 一般的なTodoアプリ                   | Markdownノートアプリ           | このツール             |
-| ------------ | ------------------------------------ | ------------------------------ | ---------------------- |
-| 機能の豊富さ | プロジェクト管理、タグ、期限など多数 | リンク、検索、フォルダ管理など | 閲覧とアーカイブのみ   |
-| ファイル管理 | アプリ内で管理                       | 複数ファイル・フォルダ         | 一つのMarkdownファイル |
-| 編集環境     | 専用エディタ                         | 専用エディタ                   | 外部エディタ（Vim等）  |
-| 利用環境     | GUI（Web/デスクトップ）              | GUI（Web/デスクトップ）        | TUI（ターミナル）      |
-| 学習コスト   | 高い（機能が多い）                   | 中〜高い                       | 低い（キー数個だけ）   |
+| Aspect | Typical Todo Apps | Markdown Note Apps | This Tool |
+| --- | --- | --- | --- |
+| Feature richness | Many: project mgmt, tags, deadlines | Links, search, folder mgmt | Only viewing and archiving |
+| File management | Managed within app | Multiple files/folders | One Markdown file |
+| Editing environment | Dedicated editor | Dedicated editor | External editor (Vim, etc.) |
+| Usage environment | GUI (Web/Desktop) | GUI (Web/Desktop) | TUI (Terminal) |
+| Learning cost | High (many features) | Medium to high | Low (just a few keys) |
 
-### このツールを選ぶ理由
+### Reasons to Choose This Tool
 
-- ターミナルから離れたくない：コマンド一つで開けます。
-- 慣れたエディタで書きたい：愛用エディタならばプラグインもキーバインドもそのまま使えます。
-- シンプルさが欲しい：機能が少ないことが価値です。
-- プレーンテキストが良い：Markdownファイルだから、どんなツールでも読めます。
+- Don't want to leave the terminal: Opens with one command.
+- Want to write with a familiar editor: Your plugins and keybindings work as-is.
+- Want simplicity: Having fewer features is the value.
+- Prefer plain text: It's a Markdown file, readable by any tool.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,74 +1,78 @@
 # ttt - Roadmap
 
-Updated: 2026-01-20
+Updated: 2026-01-22.
 
-## バージョン方針
+## Versioning Policy
 
-- セマンティックバージョニング（SemVer）に従う
-- マイナーバージョンごとに機能を追加
-- concept.md の設計思想に反する機能は追加しない
-
----
-
-## v0.2.0（リリース済み）
-
-階層タスクのサポート。
-
-- [x] インデント検出（2スペース = 1階層）
-- [x] 親タスク完了 → 子タスク自動完了
-- [x] 親タスクアーカイブ → 子タスクも一緒に移動
-- [x] Makefile追加（バージョン埋め込みビルド）
-- [x] フッターにバージョン表示
+- Follows Semantic Versioning (SemVer)
+- Features added with each minor version
+- Features violating concept.md design philosophy will not be added
 
 ---
 
-## v0.3.0（計画中）
+## v0.2.0 (Released)
 
-Git同期機能の拡張。
+Hierarchical task support.
 
-- [ ] `ttt sync` コマンド: 手動でリモートに同期
-- [ ] リモート設定: `git.remote = "origin"`
-- [ ] 自動同期: `git.auto_sync = true/false`
-
-**設定例:**
-```toml
-[git]
-auto_commit = true
-remote = "origin"
-auto_sync = false
-```
+- [x] Indentation detection (2 spaces = 1 level)
+- [x] Parent task completion → child tasks auto-complete
+- [x] Parent task archive → child tasks move together
+- [x] Makefile added (version embedding build)
+- [x] Version display in footer
 
 ---
 
-## v0.4.0（計画中）
+## v0.3.0 (In Progress)
 
-表示の改善。
+Git sync functionality and public beta preparation.
 
-- [ ] シンタックスハイライト（タスク、見出し、完了マークの色分け）
-- [ ] 簡易統計表示（今日のタスク数、完了数など）
+### Git Sync Functionality
+
+- [x] `ttt remote <url>` command: Register remote repository
+- [x] `ttt sync` command: Manual sync with remote (pull → commit → push)
+- [x] Repository file auto-generation (README.md, .gitignore)
+
+**Note:** `auto_sync` setting is not provided (manual sync only)
+
+### Public Beta Preparation
+
+- [ ] `go install github.com/yostos/tiny-task-tool@latest` support
+- [ ] Makefile improvements (go install / PREFIX variable support)
+- [ ] Homebrew formula creation (`brew install yostos/tap/ttt`)
+- [ ] Document translation to English (except TODO.md)
+- [ ] Add installation instructions to README.md
 
 ---
 
-## v0.5.0（検討中）
+## v0.4.0 (Planned)
 
-追加機能。優先度は低め、実装するかは未定。
+Display improvements.
 
-- [ ] スナップショット機能（今日の状態を保存）
-- [ ] 別ファイルへのアーカイブ（設定で選択可能）
-- [ ] 期限（`@due(YYYY-MM-DD)`）のサポート
+- [ ] Syntax highlighting (color-coding for tasks, headings, completion marks)
+- [ ] Simple statistics display (today's task count, completion count, etc.)
 
 ---
 
-## 実装しないもの
+## v0.5.0 (Under Consideration)
 
-concept.md で定義された「やらないこと」は、ロードマップに含めません。
+Additional features. Low priority, implementation undecided.
 
-- コマンドライン引数でのファイル指定
-- 複数ファイル対応
-- ファイル内編集機能
-- タスクの完了/未完了切り替え（エディタに任せる）
-- Markdownレンダリング
-- 検索・フィルタ機能
-- タグやメタデータ
-- クラウド同期（Git以外）
-- AI機能
+- [ ] Snapshot feature (save today's state)
+- [ ] Archive to separate file (selectable in settings)
+- [ ] Due date support (`@due(YYYY-MM-DD)`)
+
+---
+
+## Not To Be Implemented
+
+Features defined as "what we don't do" in concept.md are not included in the roadmap.
+
+- File specification via command-line arguments
+- Multiple file support
+- In-file editing functionality
+- Task completion toggle (leave to editor)
+- Custom Markdown rendering implementation (library usage is acceptable)
+- Search/filter functionality
+- Tags or metadata
+- Cloud sync (other than Git)
+- AI features

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -17,11 +17,28 @@ type Options struct {
 	Task        string
 	ShowHelp    bool
 	ShowVersion bool
+	RemoteURL   string // URL for "ttt remote <url>" command
+	Sync        bool   // true when "ttt sync" command is used
 }
 
 // Parse parses command-line arguments and returns Options.
 func Parse(args []string) (*Options, error) {
 	opts := &Options{}
+
+	// Check for subcommands first (before flag parsing)
+	if len(args) > 0 {
+		switch args[0] {
+		case "remote":
+			if len(args) < 2 {
+				return nil, fmt.Errorf("missing URL for 'remote' command. Usage: ttt remote <url>")
+			}
+			opts.RemoteURL = args[1]
+			return opts, nil
+		case "sync":
+			opts.Sync = true
+			return opts, nil
+		}
+	}
 
 	fs := pflag.NewFlagSet("ttt", pflag.ContinueOnError)
 	fs.StringVarP(&opts.Task, "task", "t", "", "Add a task (TUI is not launched)")
@@ -56,16 +73,24 @@ Usage:
   ttt                     Launch TUI
   ttt -t <task>           Add a task (TUI is not launched)
   ttt --task "<task>"     Add a task with quotes
+  ttt remote <url>        Set remote repository URL
+  ttt sync                Sync with remote (pull, commit, push)
 
 Options:
   -t, --task <text>   Add a task to the task file
   -h, --help          Show this help message
   -v, --version       Show version
 
+Commands:
+  remote <url>        Set or update the remote repository (origin)
+  sync                Sync with remote: pull -> commit -> push
+
 Examples:
   ttt                                    # Launch TUI
   ttt -t buy kitchen paper and wasabi    # Add task
-  ttt --task "buy kitchen paper"         # Add task with quotes`
+  ttt --task "buy kitchen paper"         # Add task with quotes
+  ttt remote git@github.com:user/tasks.git  # Set remote
+  ttt sync                               # Sync with remote`
 }
 
 // VersionString returns the version string.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,109 @@
+// Package git provides git operations for ttt.
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// SetRemote sets or updates the remote URL for origin.
+// If origin already exists, it updates the URL using set-url.
+func SetRemote(dir, url string) error {
+	if HasRemote(dir, "origin") {
+		// Update existing remote
+		cmd := exec.Command("git", "remote", "set-url", "origin", url)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to update remote: %w", err)
+		}
+	} else {
+		// Add new remote
+		cmd := exec.Command("git", "remote", "add", "origin", url)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to add remote: %w", err)
+		}
+	}
+	return nil
+}
+
+// HasRemote checks if a remote with the given name exists.
+func HasRemote(dir, name string) bool {
+	cmd := exec.Command("git", "remote", "get-url", name)
+	cmd.Dir = dir
+	return cmd.Run() == nil
+}
+
+// GetCurrentBranch returns the current branch name.
+func GetCurrentBranch(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current branch: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// Sync performs pull, commit (if needed), and push.
+// Returns an error if no remote 'origin' is configured.
+// If pull fails (e.g., remote branch doesn't exist), it skips pull and proceeds to push.
+func Sync(dir string) error {
+	// Check if remote exists
+	if !HasRemote(dir, "origin") {
+		return fmt.Errorf("no remote 'origin' configured. Use 'ttt remote <url>' first")
+	}
+
+	branch, err := GetCurrentBranch(dir)
+	if err != nil {
+		return err
+	}
+
+	// Pull from remote (skip if fails, e.g., remote branch doesn't exist yet)
+	cmd := exec.Command("git", "pull", "origin", branch)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		outputStr := string(output)
+		// Check for merge conflict - this is a real error
+		if strings.Contains(outputStr, "CONFLICT") {
+			return fmt.Errorf("merge conflict detected. Please resolve manually:\n%s", output)
+		}
+		// Other pull failures (e.g., remote ref not found) - skip and proceed to push
+		// This handles the case of first sync when remote branch doesn't exist
+	}
+
+	// Check for uncommitted changes
+	cmd = exec.Command("git", "status", "--porcelain")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to check status: %w", err)
+	}
+
+	// If there are changes, commit them
+	if len(strings.TrimSpace(string(output))) > 0 {
+		// Stage all changes
+		cmd = exec.Command("git", "add", "-A")
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to stage changes: %w", err)
+		}
+
+		// Commit
+		cmd = exec.Command("git", "commit", "-m", "Sync changes")
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to commit: %w", err)
+		}
+	}
+
+	// Push to remote
+	cmd = exec.Command("git", "push", "-u", "origin", branch)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("push failed: %s", output)
+	}
+
+	return nil
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,209 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupTestRepo creates a temporary git repository for testing.
+// Returns the path to the repository and a cleanup function.
+func setupTestRepo(t *testing.T) (string, func()) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "ttt-git-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+
+	// Configure git user for commits (errors are non-fatal for tests)
+	cmd = exec.Command("git", "config", "user.email", "test@example.com")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	// Create initial commit
+	testFile := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	cmd = exec.Command("git", "commit", "-m", "Initial commit")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	cleanup := func() {
+		_ = os.RemoveAll(dir)
+	}
+
+	return dir, cleanup
+}
+
+// TestSetRemote verifies that SetRemote() adds a new remote named "origin".
+// Spec: docs/specification.md "リモートリポジトリの登録（v0.3.0）" section
+func TestSetRemote(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	url := "https://github.com/user/repo.git"
+	err := SetRemote(dir, url)
+	if err != nil {
+		t.Fatalf("SetRemote() error: %v", err)
+	}
+
+	// Verify remote was set
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Failed to get remote URL: %v", err)
+	}
+
+	got := strings.TrimSpace(string(output))
+	if got != url {
+		t.Errorf("Remote URL = %q, want %q", got, url)
+	}
+}
+
+// TestSetRemoteUpdate verifies that SetRemote() updates existing remote.
+// Spec: docs/specification.md "origin が既に存在する場合は git remote set-url origin <url> で更新"
+func TestSetRemoteUpdate(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Set initial remote
+	oldURL := "https://github.com/old/repo.git"
+	cmd := exec.Command("git", "remote", "add", "origin", oldURL)
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to add initial remote: %v", err)
+	}
+
+	// Update remote
+	newURL := "https://github.com/new/repo.git"
+	err := SetRemote(dir, newURL)
+	if err != nil {
+		t.Fatalf("SetRemote() error: %v", err)
+	}
+
+	// Verify remote was updated
+	cmd = exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Failed to get remote URL: %v", err)
+	}
+
+	got := strings.TrimSpace(string(output))
+	if got != newURL {
+		t.Errorf("Remote URL = %q, want %q", got, newURL)
+	}
+}
+
+// TestHasRemote verifies that HasRemote() correctly detects remote existence.
+// Spec: docs/specification.md "リモートリポジトリの登録（v0.3.0）" section
+func TestHasRemote(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Initially no remote
+	if HasRemote(dir, "origin") {
+		t.Error("HasRemote() = true, want false (no remote set)")
+	}
+
+	// Add remote
+	cmd := exec.Command("git", "remote", "add", "origin", "https://example.com/repo.git")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to add remote: %v", err)
+	}
+
+	// Now should have remote
+	if !HasRemote(dir, "origin") {
+		t.Error("HasRemote() = false, want true (remote was set)")
+	}
+}
+
+// TestGetCurrentBranch verifies that GetCurrentBranch() returns the current branch name.
+// Spec: docs/specification.md "手動同期（v0.3.0）" section - sync uses current branch
+func TestGetCurrentBranch(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	branch, err := GetCurrentBranch(dir)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch() error: %v", err)
+	}
+
+	// Default branch is typically "main" or "master"
+	if branch != "main" && branch != "master" {
+		t.Errorf("GetCurrentBranch() = %q, want 'main' or 'master'", branch)
+	}
+}
+
+// TestSyncNoRemote verifies that Sync() returns error when no remote is configured.
+// Spec: docs/specification.md "リモートが未設定: Error: No remote 'origin' configured."
+func TestSyncNoRemote(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	err := Sync(dir)
+	if err == nil {
+		t.Error("Sync() should return error when no remote is configured")
+	}
+
+	// Error message should mention 'origin'
+	if err != nil && !strings.Contains(err.Error(), "origin") {
+		t.Errorf("Error message should mention 'origin', got: %v", err)
+	}
+}
+
+// TestSyncPullFailureSkipsToPush verifies that Sync() skips pull and proceeds to push
+// when pull fails (e.g., remote branch doesn't exist yet).
+// Spec: docs/specification.md "pull失敗（リモートにブランチなし等）: pull をスキップして commit → push を実行"
+func TestSyncPullFailureSkipsToPush(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Create a bare remote repository (no branches yet)
+	remoteDir, err := os.MkdirTemp("", "ttt-git-remote-*")
+	if err != nil {
+		t.Fatalf("Failed to create remote dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(remoteDir) }()
+
+	cmd := exec.Command("git", "init", "--bare")
+	cmd.Dir = remoteDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to init bare repo: %v", err)
+	}
+
+	// Add remote pointing to bare repo
+	if err := SetRemote(dir, remoteDir); err != nil {
+		t.Fatalf("SetRemote() error: %v", err)
+	}
+
+	// Sync should succeed (pull fails but push should work)
+	err = Sync(dir)
+	if err != nil {
+		t.Errorf("Sync() should succeed on first sync, got error: %v", err)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEnsureRepoFilesCreatesReadme verifies that ensureRepoFiles creates README.md
+// when it doesn't exist.
+// Spec: docs/specification.md "リポジトリファイルの自動生成（v0.3.0）" section
+func TestEnsureRepoFilesCreatesReadme(t *testing.T) {
+	dir := t.TempDir()
+
+	err := ensureRepoFiles(dir)
+	if err != nil {
+		t.Fatalf("ensureRepoFiles() error: %v", err)
+	}
+
+	readmePath := filepath.Join(dir, "README.md")
+	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
+		t.Error("README.md was not created")
+	}
+
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("Failed to read README.md: %v", err)
+	}
+
+	// Verify README.md contains required elements per spec
+	requiredElements := []string{
+		"My Tasks",
+		"ttt",
+		"tasks.md",
+		"archive.md",
+		"https://github.com/yostos/tiny-task-tool",
+		"Created by ttt",
+	}
+	for _, elem := range requiredElements {
+		if !strings.Contains(string(content), elem) {
+			t.Errorf("README.md should contain %q", elem)
+		}
+	}
+}
+
+// TestEnsureRepoFilesCreatesGitignore verifies that ensureRepoFiles creates .gitignore
+// when it doesn't exist.
+// Spec: docs/specification.md "リポジトリファイルの自動生成（v0.3.0）" section
+func TestEnsureRepoFilesCreatesGitignore(t *testing.T) {
+	dir := t.TempDir()
+
+	err := ensureRepoFiles(dir)
+	if err != nil {
+		t.Fatalf("ensureRepoFiles() error: %v", err)
+	}
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
+		t.Error(".gitignore was not created")
+	}
+
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("Failed to read .gitignore: %v", err)
+	}
+
+	// Verify .gitignore contains OS and editor patterns per spec
+	requiredPatterns := []string{
+		// macOS
+		".DS_Store",
+		// Windows
+		"Thumbs.db",
+		// Linux/General
+		"*~",
+		// Vim
+		"*.swp",
+		// VS Code
+		".vscode/",
+	}
+	for _, pattern := range requiredPatterns {
+		if !strings.Contains(string(content), pattern) {
+			t.Errorf(".gitignore should contain %q", pattern)
+		}
+	}
+}
+
+// TestEnsureRepoFilesDoesNotOverwrite verifies that ensureRepoFiles does not
+// overwrite existing files.
+// Spec: docs/specification.md "存在しない場合は自動生成"
+func TestEnsureRepoFilesDoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create existing files with custom content
+	readmePath := filepath.Join(dir, "README.md")
+	customReadme := "# Custom README\n"
+	if err := os.WriteFile(readmePath, []byte(customReadme), 0644); err != nil {
+		t.Fatalf("Failed to create custom README.md: %v", err)
+	}
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	customGitignore := "# Custom gitignore\n"
+	if err := os.WriteFile(gitignorePath, []byte(customGitignore), 0644); err != nil {
+		t.Fatalf("Failed to create custom .gitignore: %v", err)
+	}
+
+	// Run ensureRepoFiles
+	err := ensureRepoFiles(dir)
+	if err != nil {
+		t.Fatalf("ensureRepoFiles() error: %v", err)
+	}
+
+	// Verify files were not overwritten
+	readmeContent, _ := os.ReadFile(readmePath)
+	if string(readmeContent) != customReadme {
+		t.Error("README.md was overwritten")
+	}
+
+	gitignoreContent, _ := os.ReadFile(gitignorePath)
+	if string(gitignoreContent) != customGitignore {
+		t.Error(".gitignore was overwritten")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ttt remote <url>` command to register remote repository
- Add `ttt sync` command for manual sync (pull → commit → push)
- Auto-generate README.md and .gitignore in working directory
- Update Makefile with PREFIX variable support
- Add installation instructions to README.md
- Translate all documentation to English (except TODO.md)

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] User tested `ttt remote` and `ttt sync` commands
- [x] Verified first sync scenario (remote branch doesn't exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)